### PR TITLE
Fix #20 cheese slice can be replaced by bread

### DIFF
--- a/tasty_supplies/core/aliases.py
+++ b/tasty_supplies/core/aliases.py
@@ -12,6 +12,7 @@ Note: Pottery sherds can be more easily used in recipes with the crafting table,
 # Food items
 BARNACLE_THONG: str = "guster_banner_pattern"
 BUTTER: str = "poisonous_potato"
+CHEESE_SLICE: str = "piglin_banner_pattern"
 COOKED_BACON: str = "skull_banner_pattern"
 COOKED_BARNACLE_THONG: str = "creeper_banner_pattern"
 COOKED_RICE: str = "field_masoned_banner_pattern"

--- a/tasty_supplies/core/recipes/meals.py
+++ b/tasty_supplies/core/recipes/meals.py
@@ -82,6 +82,7 @@ class Meals(Category):
             Item(
                 "cheese_slice",
                 food={"nutrition": 2, "saturation": 1.4},
+                base_item=aliases.CHEESE_SLICE,
             )
         )
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add a CHEESE_SLICE item alias and use it as the base item for the cheese_slice meal recipe so it no longer conflicts with bread.